### PR TITLE
Initial implementation to read .ini files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "thirdparty/Boost.SmartPtr"]
 	path = thirdparty/Boost.SmartPtr
 	url = https://github.com/boostorg/smart_ptr.git
+[submodule "thirdparty/inih"]
+	path = thirdparty/inih
+	url = https://github.com/jtilly/inih

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries (smartcar_emul_deps INTERFACE
         )
 
 add_executable (smartcar_emul src/main.cxx)
-target_include_directories (smartcar_emul PRIVATE include)
+target_include_directories (smartcar_emul PRIVATE include thirdparty/inih)
 target_link_libraries (smartcar_emul PRIVATE smartcar_emul_deps)
 target_compile_options (smartcar_emul PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/permissive->)
 

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -13,3 +13,4 @@
 #
 
 add_subdirectory (trycompile)
+add_subdirectory (configloader)

--- a/modules/configloader/CMakeLists.txt
+++ b/modules/configloader/CMakeLists.txt
@@ -23,7 +23,7 @@ target_sources(ConfigLoader INTERFACE
         include/configloader/Loader.hxx
         src/Loader.cxx)
 
-target_link_libraries(TryCompile INTERFACE stdpolyfills::stdpolyfills)
+target_link_libraries(ConfigLoader INTERFACE stdpolyfills::stdpolyfills fmt::fmt)
 
 add_executable(TestsConfigLoader test/load.cxx)
 

--- a/modules/configloader/CMakeLists.txt
+++ b/modules/configloader/CMakeLists.txt
@@ -1,0 +1,34 @@
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+add_library(ConfigLoader INTERFACE)
+
+target_include_directories(ConfigLoader INTERFACE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/configloader
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_SOURCE_DIR}/thirdparty/inih)
+
+target_sources(ConfigLoader INTERFACE
+        include/configloader/Loader.hxx
+        src/Loader.cxx)
+
+target_link_libraries(TryCompile INTERFACE stdpolyfills::stdpolyfills)
+
+add_executable(TestsConfigLoader test/load.cxx)
+
+set_target_properties(TestsConfigLoader PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(TestsConfigLoader ConfigLoader Catch2)
+
+catch_discover_tests(TestsConfigLoader)
+add_dependencies(TestTag TestsConfigLoader)

--- a/modules/configloader/CMakeLists.txt
+++ b/modules/configloader/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(ConfigLoader INTERFACE)
 target_include_directories(ConfigLoader INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/include/configloader
         ${CMAKE_SOURCE_DIR}/include
-        ${CMAKE_SOURCE_DIR}/thirdparty/inih)
+        ${CMAKE_SOURCE_DIR}/thirdparty)
 
 target_sources(ConfigLoader INTERFACE
         include/configloader/Loader.hxx

--- a/modules/configloader/include/configloader/Loader.hxx
+++ b/modules/configloader/include/configloader/Loader.hxx
@@ -1,0 +1,48 @@
+/*
+ *  Loader.hxx
+ *  Copyright 2020 ItJustWorksTM
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef SMARTCAR_EMUL_LOADER_HXX
+#define SMARTCAR_EMUL_LOADER_HXX
+#include <filesystem>
+
+namespace smce {
+namespace stdfs = std::filesystem;
+
+struct ProgramOptions {
+    static constexpr auto DEFAULT_PREPROCESSOR_BIN = "bin";
+    static constexpr auto DEFAULT_SMCE_HOME = ".";
+    static constexpr auto DEFAULT_LIB_PATH = ".";
+    static constexpr int DEFAULT_CPP_STD = 17;
+
+    stdfs::path preprocessor_bin;
+    stdfs::path smce_home;
+    stdfs::path lib_path;
+    int cpp_std;
+
+    ProgramOptions(stdfs::path preprocessor_bin, stdfs::path smce_home, stdfs::path lib_path, int cpp_std)
+        : preprocessor_bin{std::move(preprocessor_bin)}, smce_home{std::move(smce_home)}, lib_path{std::move(lib_path)}, cpp_std{cpp_std} {}
+
+    ProgramOptions()
+        : preprocessor_bin{DEFAULT_PREPROCESSOR_BIN}, smce_home{DEFAULT_SMCE_HOME}, lib_path{DEFAULT_LIB_PATH}, cpp_std{DEFAULT_CPP_STD} {}
+};
+
+ProgramOptions LoadProgramOptions(const stdfs::path& file);
+
+} // namespace smce
+
+#endif // SMARTCAR_EMUL_LOADER_HXX

--- a/modules/configloader/include/configloader/Loader.hxx
+++ b/modules/configloader/include/configloader/Loader.hxx
@@ -42,6 +42,7 @@ struct ProgramOptions {
 };
 
 ProgramOptions LoadProgramOptions(const stdfs::path& file);
+void ExportPorgramOptions(const ProgramOptions& config, const stdfs::path& path);
 
 } // namespace smce
 

--- a/modules/configloader/include/configloader/Loader.hxx
+++ b/modules/configloader/include/configloader/Loader.hxx
@@ -24,7 +24,7 @@ namespace smce {
 namespace stdfs = std::filesystem;
 
 struct ProgramOptions {
-    static constexpr auto DEFAULT_PREPROCESSOR_BIN = "bin";
+    static constexpr auto DEFAULT_PREPROCESSOR_BIN = "";
     static constexpr auto DEFAULT_SMCE_HOME = ".";
     static constexpr auto DEFAULT_LIB_PATH = ".";
     static constexpr int DEFAULT_CPP_STD = 17;
@@ -42,7 +42,7 @@ struct ProgramOptions {
 };
 
 ProgramOptions LoadProgramOptions(const stdfs::path& file);
-void ExportPorgramOptions(const ProgramOptions& config, const stdfs::path& path);
+void ExportProgramOptions(const ProgramOptions& config, const stdfs::path& path);
 
 } // namespace smce
 

--- a/modules/configloader/src/Loader.cxx
+++ b/modules/configloader/src/Loader.cxx
@@ -18,9 +18,10 @@
 
 #include <fstream>
 #include <string>
-#include "fmt/format.h"
-#include "INIReader.h"
+#include <fmt/format.h>
+#include <inih/INIReader.h>
 #include "Loader.hxx"
+
 namespace smce {
 
 ProgramOptions LoadProgramOptions(const stdfs::path& path) {
@@ -42,7 +43,7 @@ ProgramOptions LoadProgramOptions(const stdfs::path& path) {
     return config;
 }
 
-void ExportPorgramOptions(const ProgramOptions& co, const stdfs::path& path) {
+void ExportProgramOptions(const ProgramOptions& co, const stdfs::path& path) {
     if (std::ofstream out(path, std::ios::out | std::ios::binary); out) {
         auto ret = fmt::format("[paths]\npreprocessor_bin={}\nsmce_home={}\nlib_path={}\n[versions]\ncpp_std={}\n", co.preprocessor_bin.string(),
                                co.smce_home.string(), co.lib_path.string(), co.cpp_std);

--- a/modules/configloader/src/Loader.cxx
+++ b/modules/configloader/src/Loader.cxx
@@ -1,0 +1,43 @@
+/*
+ *  Loader.cxx
+ *  Copyright 2020 ItJustWorksTM
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include <string>
+#include "INIReader.h"
+#include "Loader.hxx"
+namespace smce {
+
+ProgramOptions LoadProgramOptions(const stdfs::path& path) {
+    auto reader = INIReader(path.string());
+
+    if (reader.ParseError() != 0)
+        return ProgramOptions{};
+
+    auto read_ini_path = [&](std::string_view section, std::string_view name, std::string_view sub) -> stdfs::path {
+        auto tmp = reader.Get(section.data(), name.data(), sub.data());
+        return stdfs::exists(tmp) ? tmp : sub;
+    };
+
+    ProgramOptions config(read_ini_path("paths", "preprocessor_bin", ProgramOptions::DEFAULT_PREPROCESSOR_BIN),
+                          read_ini_path("paths", "smce_home", ProgramOptions::DEFAULT_SMCE_HOME),
+                          read_ini_path("paths", "lib_path", ProgramOptions::DEFAULT_LIB_PATH),
+                          reader.GetInteger("versions", "cpp_std", ProgramOptions::DEFAULT_CPP_STD));
+
+    return config;
+}
+
+} // namespace smce

--- a/modules/configloader/src/Loader.cxx
+++ b/modules/configloader/src/Loader.cxx
@@ -16,7 +16,9 @@
  *
  */
 
+#include <fstream>
 #include <string>
+#include "fmt/format.h"
 #include "INIReader.h"
 #include "Loader.hxx"
 namespace smce {
@@ -38,6 +40,14 @@ ProgramOptions LoadProgramOptions(const stdfs::path& path) {
                           reader.GetInteger("versions", "cpp_std", ProgramOptions::DEFAULT_CPP_STD));
 
     return config;
+}
+
+void ExportPorgramOptions(const ProgramOptions& co, const stdfs::path& path) {
+    if (std::ofstream out(path, std::ios::out | std::ios::binary); out) {
+        auto ret = fmt::format("[paths]\npreprocessor_bin={}\nsmce_home={}\nlib_path={}\n[versions]\ncpp_std={}\n", co.preprocessor_bin.string(),
+                               co.smce_home.string(), co.lib_path.string(), co.cpp_std);
+        out.write(ret.data(), ret.size());
+    }
 }
 
 } // namespace smce

--- a/modules/configloader/test/load.cxx
+++ b/modules/configloader/test/load.cxx
@@ -12,7 +12,7 @@ bool write_file(const stdfs::path& source_path, std::string_view src) {
     return false;
 }
 
-TEST_CASE("Load config file", "load config") {
+TEST_CASE("Load config file", "[load config]") {
     constexpr auto ini = R"([paths]
 preprocessor_bin=testing
 smce_home=testing
@@ -35,7 +35,7 @@ cpp_std=14
     REQUIRE(config.cpp_std == 14);
 }
 
-TEST_CASE("Non existent directories", "load bad dirs config") {
+TEST_CASE("Non existent directories", "[load bad dirs config]") {
     constexpr auto ini = R"([paths]
 preprocessor_bin=nottesting
 smce_home=nottesting
@@ -54,7 +54,7 @@ cpp_std=17
     REQUIRE(config.cpp_std == 17);
 }
 
-TEST_CASE("Parsing fail config", "Parse fail") {
+TEST_CASE("Parsing fail config", "[Parse fail]") {
     constexpr auto ini = R"(ths]
 preprocessor_bin=nottesting
 lib_path=nottesting
@@ -70,4 +70,23 @@ cpp_std17
     REQUIRE(config.smce_home == ".");
     REQUIRE(config.lib_path == ".");
     REQUIRE(config.cpp_std == 17);
+}
+
+TEST_CASE("Export config", "[Export config]") {
+    std::error_code e;
+    std::filesystem::create_directory("helloworld", e);
+    REQUIRE(!e);
+
+    auto test = smce::ProgramOptions{};
+    test.cpp_std = 11;
+    test.smce_home = "helloworld";
+
+    const auto out = stdfs::path{"export.ini"};
+    smce::ExportPorgramOptions(test, out);
+    const auto comp = smce::LoadProgramOptions(out);
+
+    REQUIRE(test.preprocessor_bin == comp.preprocessor_bin);
+    REQUIRE(test.smce_home == comp.smce_home);
+    REQUIRE(test.lib_path == comp.lib_path);
+    REQUIRE(test.cpp_std == comp.cpp_std);
 }

--- a/modules/configloader/test/load.cxx
+++ b/modules/configloader/test/load.cxx
@@ -1,0 +1,73 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include "Loader.hxx"
+
+namespace stdfs = std::filesystem;
+
+bool write_file(const stdfs::path& source_path, std::string_view src) {
+    if (std::ofstream out(source_path, std::ios::out | std::ios::binary); out) {
+        out.write(src.data(), src.size());
+        return true;
+    }
+    return false;
+}
+
+TEST_CASE("Load config file", "load config") {
+    constexpr auto ini = R"([paths]
+preprocessor_bin=testing
+smce_home=testing
+lib_path=testing
+[versions]
+cpp_std=14
+)";
+    constexpr auto ini_name = "sample.ini";
+
+    std::error_code e;
+    std::filesystem::create_directory("testing", e);
+    REQUIRE(!e);
+
+    REQUIRE(write_file(ini_name, ini));
+    auto config = smce::LoadProgramOptions(ini_name);
+
+    REQUIRE(config.preprocessor_bin == "testing");
+    REQUIRE(config.smce_home == "testing");
+    REQUIRE(config.lib_path == "testing");
+    REQUIRE(config.cpp_std == 14);
+}
+
+TEST_CASE("Non existent directories", "load bad dirs config") {
+    constexpr auto ini = R"([paths]
+preprocessor_bin=nottesting
+smce_home=nottesting
+lib_path=nottesting
+[versions]
+cpp_std=17
+)";
+    constexpr auto ini_name = "sample_bad.ini";
+
+    REQUIRE(write_file(ini_name, ini));
+    auto config = smce::LoadProgramOptions(ini_name);
+
+    REQUIRE(config.preprocessor_bin == "bin");
+    REQUIRE(config.smce_home == ".");
+    REQUIRE(config.lib_path == ".");
+    REQUIRE(config.cpp_std == 17);
+}
+
+TEST_CASE("Parsing fail config", "Parse fail") {
+    constexpr auto ini = R"(ths]
+preprocessor_bin=nottesting
+lib_path=nottesting
+[vers
+cpp_std17
+)";
+    constexpr auto ini_name = "sample_fail.ini";
+
+    REQUIRE(write_file(ini_name, ini));
+    auto config = smce::LoadProgramOptions(ini_name);
+
+    REQUIRE(config.preprocessor_bin == "bin");
+    REQUIRE(config.smce_home == ".");
+    REQUIRE(config.lib_path == ".");
+    REQUIRE(config.cpp_std == 17);
+}

--- a/modules/configloader/test/load.cxx
+++ b/modules/configloader/test/load.cxx
@@ -48,7 +48,7 @@ cpp_std=17
     REQUIRE(write_file(ini_name, ini));
     auto config = smce::LoadProgramOptions(ini_name);
 
-    REQUIRE(config.preprocessor_bin == "bin");
+    REQUIRE(config.preprocessor_bin == "");
     REQUIRE(config.smce_home == ".");
     REQUIRE(config.lib_path == ".");
     REQUIRE(config.cpp_std == 17);
@@ -66,7 +66,7 @@ cpp_std17
     REQUIRE(write_file(ini_name, ini));
     auto config = smce::LoadProgramOptions(ini_name);
 
-    REQUIRE(config.preprocessor_bin == "bin");
+    REQUIRE(config.preprocessor_bin == "");
     REQUIRE(config.smce_home == ".");
     REQUIRE(config.lib_path == ".");
     REQUIRE(config.cpp_std == 17);
@@ -82,7 +82,7 @@ TEST_CASE("Export config", "[Export config]") {
     test.smce_home = "helloworld";
 
     const auto out = stdfs::path{"export.ini"};
-    smce::ExportPorgramOptions(test, out);
+    smce::ExportProgramOptions(test, out);
     const auto comp = smce::LoadProgramOptions(out);
 
     REQUIRE(test.preprocessor_bin == comp.preprocessor_bin);


### PR DESCRIPTION
Maps ini to internal format and fills in gaps.
fixes #11 

Supported for now:
* arduino preprocessor binary path
* smce_home (prefix where /share is)
* library path (for arduino libs)
* sketch's C++ standard