### PR TITLE
Handle dynamic init IO

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -102,8 +102,10 @@ jobs:
           mkdir build && pushd build && URHO3D_HOME=$(realpath ../Urho3D) cmake -G Ninja .. && popd
       - name: build
         run: |
-          export CC=cc;
-          export CXX=c++;
+          if [ $(echo "$CC" | grep -Ei "^clang-") ]; then
+            export CC=/usr/local/opt/llvm/bin/clang;
+            export CXX=/usr/local/opt/llvm/bin/clang++;
+          fi
           cmake --build build
 #      - name: test
 #        run: pushd build && ctest && popd

--- a/include/utility.hxx
+++ b/include/utility.hxx
@@ -66,4 +66,8 @@ struct Visitor : Base... {
 template <typename... T>
 Visitor(T...) -> Visitor<T...>;
 
+template <class T, class V> void visit(V&& v, T&& t) {
+    [v=std::forward<V>(v), t=std::forward<T>(t)]<size_t... I>(std::index_sequence<I...>) { (..., v(std::get<I>(t))); }(std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<T>>>());
+}
+
 #endif // SMARTCAR_EMUL_INCLUDE_UTILITY_HXX

--- a/modules/ardrivo/include/ardrivo/Entrypoint.hxx
+++ b/modules/ardrivo/include/ardrivo/Entrypoint.hxx
@@ -23,5 +23,6 @@ struct BoardData;
 struct BoardInfo;
 
 bool init(BoardData*, const BoardInfo*);
+void maybe_init() noexcept;
 
 #endif // SMARTCAR_EMUL_ENTRYPOINT_HXX

--- a/modules/ardrivo/src/Arduino.cxx
+++ b/modules/ardrivo/src/Arduino.cxx
@@ -26,6 +26,7 @@
 #include "BoardData.hxx"
 #include "BoardDataDef.hxx"
 #include "BoardInfo.hxx"
+#include "Entrypoint.hxx"
 #include "Error.hxx"
 
 using namespace std::literals;
@@ -35,6 +36,7 @@ using namespace std::literals;
 }
 
 void pinMode(uint8_t pin, uint8_t mode) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("pinMode({}, {}): {}", pin, mode, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"));
@@ -46,6 +48,7 @@ void pinMode(uint8_t pin, uint8_t mode) {
 }
 
 void digitalWrite(uint8_t pin, bool val) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("digitalWrite({}, {}): {}", pin, val, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"));
@@ -55,6 +58,7 @@ void digitalWrite(uint8_t pin, bool val) {
 }
 
 int digitalRead(uint8_t pin) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("digitalRead({}): {}", pin, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"), LOW);
@@ -64,6 +68,7 @@ int digitalRead(uint8_t pin) {
 }
 
 void analogWrite(uint16_t pin, uint16_t val) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("analogWrite({}, {}): {}", pin, val, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"));
@@ -73,6 +78,7 @@ void analogWrite(uint16_t pin, uint16_t val) {
 }
 
 int analogRead(uint8_t pin) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("analogRead({}): {}", pin, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"), 0);
@@ -84,6 +90,7 @@ int analogRead(uint8_t pin) {
 void analogReference(uint8_t mode) {}
 
 void noTone(uint8_t pin) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("noTone({}): {}", pin, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"));
@@ -92,6 +99,7 @@ void noTone(uint8_t pin) {
 }
 
 void tone(uint8_t pin, unsigned int frequency, unsigned long duration) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("tone({}, {}, {}): {}", pin, frequency, duration, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"));
@@ -101,6 +109,7 @@ void tone(uint8_t pin, unsigned int frequency, unsigned long duration) {
 }
 
 unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("pulseIn({}, {}, {}): {}", pin, state, timeout, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"), 0);
@@ -130,6 +139,7 @@ unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout) {
 }
 
 unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("pulseInLong({}, {}, {}): {}", pin, state, timeout, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"), 0);
@@ -137,6 +147,7 @@ unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout) {
 }
 
 void shiftOut(uint8_t data_pin, uint8_t clock_pin, uint8_t bit_order, uint8_t val) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("shiftOut({}, {}, {}, {}): {}", data_pin, clock_pin, bit_order, val, msg); };
     if (data_pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"));
@@ -155,6 +166,7 @@ void shiftOut(uint8_t data_pin, uint8_t clock_pin, uint8_t bit_order, uint8_t va
     }
 }
 uint8_t shiftIn(uint8_t data_pin, uint8_t clock_pin, uint8_t bit_order) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("shiftIn({}, {}, {}): {}", data_pin, clock_pin, bit_order, msg); };
     if (data_pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"), '\x00');
@@ -173,12 +185,14 @@ void delay(unsigned long duration) { std::this_thread::sleep_for(std::chrono::mi
 void delayMicroseconds(unsigned int duration) { std::this_thread::sleep_for(std::chrono::microseconds(duration)); }
 
 unsigned long micros() {
+    maybe_init();
     const auto current_time = std::chrono::steady_clock::now();
     const unsigned long duration = std::chrono::duration_cast<std::chrono::microseconds>(current_time - board_data->start_time).count();
     return duration;
 }
 
 unsigned long millis() {
+    maybe_init();
     const auto current_time = std::chrono::steady_clock::now();
     const unsigned long duration = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - board_data->start_time).count();
     return duration;
@@ -211,6 +225,7 @@ void randomSeed(unsigned long seed) { return std::srand(seed); }
 
 // Arduino External Interrupts functions
 void attachInterrupt(uint8_t pin, void (*user_func)(), int mode) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("attachInterrupt({}, /* function pointer */, {}): {}", pin, mode, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"));
@@ -221,6 +236,7 @@ void attachInterrupt(uint8_t pin, void (*user_func)(), int mode) {
         board_data->interrupts_handlers[pin] = std::pair{user_func, mode};
 }
 void detachInterrupt(uint8_t pin) {
+    maybe_init();
     const auto debug_sig = [=](const char* msg) { return fmt::format("detachInterrupt({}): {}", pin, msg); };
     if (pin >= board_info->pins_caps.size())
         return handle_error(debug_sig("Pin does not exist"));

--- a/modules/ardrivo/src/Entrypoint.cxx
+++ b/modules/ardrivo/src/Entrypoint.cxx
@@ -48,7 +48,7 @@ void maybe_init() noexcept {
     // over-allocate everything to handle possible IO at dynamic-init
     auto loc_board_data = std::make_unique<BoardData>();
     loc_board_data->silence_errors = true;
-    loc_board_data->start_time = std::chrono::steady_clock::now();
+    loc_board_data->start_time = {};
     loc_board_data->pin_modes = std::vector<std::atomic_uint8_t>(255);
     loc_board_data->digital_pin_values = std::vector<std::atomic_bool>(255);
     loc_board_data->analog_pin_values = std::vector<std::atomic_uint16_t>(255);

--- a/modules/ardrivo/src/Entrypoint.cxx
+++ b/modules/ardrivo/src/Entrypoint.cxx
@@ -16,15 +16,46 @@
  *
  */
 
+#include <memory>
+#include <range/v3/algorithm/for_each.hpp>
 #include "BoardData.hxx"
 #include "BoardInfo.hxx"
 #include "Entrypoint.hxx"
 
-BoardData* board_data;
-const BoardInfo* board_info;
+BoardData* board_data = nullptr;
+const BoardInfo* board_info = nullptr;
 
 bool init(BoardData* brd, const BoardInfo* info) {
+    if (board_data) {
+        auto defer_del_bd = std::unique_ptr<BoardData>{board_data};
+        auto defer_del_bi = std::unique_ptr<const BoardInfo>{board_info};
+        delete board_info;
+        //merge_config();
+    }
     board_data = brd;
     board_info = info;
     return true;
+}
+
+void maybe_init() noexcept {
+    if (board_data)
+        return;
+
+    // over-allocate everything to handle possible IO at dynamic-init
+    board_data = new BoardData;
+    board_data->silence_errors = true;
+    board_data->start_time = std::chrono::steady_clock::now();
+    board_data->pin_modes = std::vector<std::atomic_uint8_t>(255);
+    board_data->digital_pin_values = std::vector<std::atomic_bool>(255);
+    board_data->analog_pin_values = std::vector<std::atomic_uint16_t>(255);
+    board_data->i2c_buses = std::vector<I2cBus>(64);
+    board_data->uart_buses = std::vector<UartBus>(64);
+    board_data->interrupts_handlers = decltype(board_data->interrupts_handlers)(255);
+
+    BoardInfo* loc_board_info = new BoardInfo;
+    loc_board_info->pins_caps.resize(255);
+    ranges::for_each(loc_board_info->pins_caps, [](PinCapability& pin){ pin.digital_in = pin.digital_out = true; }); // default to all digital-able
+    // Protocol-pins need not be set as we cannot do pin-locking detection during dynamic-init anyway
+
+    ::board_info = loc_board_info;
 }

--- a/modules/ardrivo/src/Entrypoint.cxx
+++ b/modules/ardrivo/src/Entrypoint.cxx
@@ -48,7 +48,7 @@ void maybe_init() noexcept {
     // over-allocate everything to handle possible IO at dynamic-init
     auto loc_board_data = std::make_unique<BoardData>();
     loc_board_data->silence_errors = true;
-    loc_board_data->start_time = {};
+    loc_board_data->start_time = std::chrono::steady_clock::now();
     loc_board_data->pin_modes = std::vector<std::atomic_uint8_t>(255);
     loc_board_data->digital_pin_values = std::vector<std::atomic_bool>(255);
     loc_board_data->analog_pin_values = std::vector<std::atomic_uint16_t>(255);

--- a/modules/ardrivo/src/Entrypoint.cxx
+++ b/modules/ardrivo/src/Entrypoint.cxx
@@ -16,21 +16,25 @@
  *
  */
 
+#include <algorithm>
 #include <memory>
 #include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/view/zip.hpp>
 #include "BoardData.hxx"
 #include "BoardInfo.hxx"
 #include "Entrypoint.hxx"
+#include "utility.hxx"
 
 BoardData* board_data = nullptr;
 const BoardInfo* board_info = nullptr;
+
+void merge_boards(BoardData old_board, BoardData& new_board) noexcept;
 
 bool init(BoardData* brd, const BoardInfo* info) {
     if (board_data) {
         auto defer_del_bd = std::unique_ptr<BoardData>{board_data};
         auto defer_del_bi = std::unique_ptr<const BoardInfo>{board_info};
-        delete board_info;
-        //merge_config();
+        merge_boards(std::move(*board_data), *brd);
     }
     board_data = brd;
     board_info = info;
@@ -42,20 +46,40 @@ void maybe_init() noexcept {
         return;
 
     // over-allocate everything to handle possible IO at dynamic-init
-    board_data = new BoardData;
-    board_data->silence_errors = true;
-    board_data->start_time = std::chrono::steady_clock::now();
-    board_data->pin_modes = std::vector<std::atomic_uint8_t>(255);
-    board_data->digital_pin_values = std::vector<std::atomic_bool>(255);
-    board_data->analog_pin_values = std::vector<std::atomic_uint16_t>(255);
-    board_data->i2c_buses = std::vector<I2cBus>(64);
-    board_data->uart_buses = std::vector<UartBus>(64);
-    board_data->interrupts_handlers = decltype(board_data->interrupts_handlers)(255);
+    auto loc_board_data = std::make_unique<BoardData>();
+    loc_board_data->silence_errors = true;
+    loc_board_data->start_time = std::chrono::steady_clock::now();
+    loc_board_data->pin_modes = std::vector<std::atomic_uint8_t>(255);
+    loc_board_data->digital_pin_values = std::vector<std::atomic_bool>(255);
+    loc_board_data->analog_pin_values = std::vector<std::atomic_uint16_t>(255);
+    loc_board_data->i2c_buses = std::vector<I2cBus>(64);
+    loc_board_data->uart_buses = std::vector<UartBus>(64);
+    loc_board_data->interrupts_handlers = decltype(board_data->interrupts_handlers)(255);
+    board_data = loc_board_data.release();
 
-    BoardInfo* loc_board_info = new BoardInfo;
+    auto loc_board_info = std::make_unique<BoardInfo>();
     loc_board_info->pins_caps.resize(255);
     ranges::for_each(loc_board_info->pins_caps, [](PinCapability& pin){ pin.digital_in = pin.digital_out = true; }); // default to all digital-able
     // Protocol-pins need not be set as we cannot do pin-locking detection during dynamic-init anyway
 
-    ::board_info = loc_board_info;
+    ::board_info = loc_board_info.release();
+}
+
+void merge_boards(BoardData old_board, BoardData& new_board) noexcept {
+    new_board.start_time = old_board.start_time;
+    new_board.interrupts_handlers = std::move(old_board.interrupts_handlers);
+
+    auto copy_atomic_vals = [&]<class T>(std::vector<T>(BoardData::* mvec)) {
+            std::transform((old_board.*mvec).begin(), (old_board.*mvec).begin() + (std::min)((old_board.*mvec).size(), (new_board.*mvec).size()),
+                           (new_board.*mvec).begin(), []<class U>(const std::atomic<U>& v) -> U { return v; });
+        };
+    visit(copy_atomic_vals, std::tuple{&BoardData::pin_modes, &BoardData::digital_pin_values, &BoardData::analog_pin_values, &BoardData::servo_value});
+
+    auto copy_proto_bufs = [&]<class T>(std::vector<T>(BoardData::* mvec)) {
+        for(auto [from, to] : ranges::views::zip(old_board.*mvec, new_board.*mvec))
+            std::tie(to.rx, to.tx) = std::forward_as_tuple(from.rx, from.tx);
+    };
+
+    copy_proto_bufs(&BoardData::i2c_buses);
+    copy_proto_bufs(&BoardData::uart_buses);
 }

--- a/modules/ardrivo/src/HardwareSerial.cxx
+++ b/modules/ardrivo/src/HardwareSerial.cxx
@@ -19,9 +19,14 @@
 #include <iostream>
 #include <limits>
 #include "BoardDataDef.hxx"
+#include "Entrypoint.hxx"
 #include "HardwareSerial.h"
 
-void HardwareSerial::begin(unsigned long, uint8_t) { begun = true; }
+
+void HardwareSerial::begin(unsigned long, uint8_t) {
+    maybe_init();
+    begun = true;
+}
 
 void HardwareSerial::end() { begun = false; }
 
@@ -33,14 +38,14 @@ int HardwareSerial::available() {
 int HardwareSerial::availableForWrite() { return std::numeric_limits<int>::max(); }
 
 size_t HardwareSerial::write(uint8_t c) {
-    if (!begun)
+    if (!begun || !board_data->write_byte)
         return 0;
     board_data->write_byte(c);
     return 1;
 }
 
 size_t HardwareSerial::write(const uint8_t* buf, std::size_t n) {
-    if (!begun)
+    if (!begun || !board_data->write_buf)
         return 0;
     board_data->write_buf(buf, n);
     return n;


### PR DESCRIPTION
Working partial fix for #34
Closes #34

Allows for calls to IO functions at dynamic init
Caveats:
- Any IO on pins that do not exist is discarded before call to `setup`
- Any IO on pins above 255 is immediately discarded
- Error policy is always silent during dynamic init