### PR TITLE
[ardrivo] Don't reset i2c slave_address in endTransmission

### DIFF
--- a/modules/ardrivo/src/Wire.cxx
+++ b/modules/ardrivo/src/Wire.cxx
@@ -101,7 +101,6 @@ std::uint8_t TwoWire::endTransmission(std::uint8_t) {
     }
 
     write_buf_used = 0;
-    slave_address = no_address;
     if (truncated_buf) {
         truncated_buf = false;
         return RetCode::truncated_data;


### PR DESCRIPTION
Fixes bug where read()&co just default to no_address
