### PR TITLE
[ardrivo] Add missing definition for global Arduino symbol `Wire`

### DIFF
--- a/modules/ardrivo/src/Wire.cxx
+++ b/modules/ardrivo/src/Wire.cxx
@@ -8,6 +8,8 @@
 #include "Wire.h"
 #include "utility.hxx"
 
+TwoWire Wire;
+
 void TwoWire::begin() { begun = true; }
 
 void TwoWire::begin(std::uint8_t with_address) {


### PR DESCRIPTION
Closes #73 