### PR TITLE
Remove unwanted and useless header-dependency chain

### DIFF
--- a/include/ardpolyfills/Wire.h
+++ b/include/ardpolyfills/Wire.h
@@ -5,7 +5,6 @@
 #include <array>
 #include <cstdint>
 #include <optional>
-#include "BoardData.hxx"
 #include "Stream.h"
 
 class TwoWire : public Stream {


### PR DESCRIPTION
ardpolyfills header should not include anything other than standard headers and themselves